### PR TITLE
Update example usage

### DIFF
--- a/.github/workflows/test-as-job.yml
+++ b/.github/workflows/test-as-job.yml
@@ -35,7 +35,7 @@ jobs:
   test-outputs:
     name: Test Outputs
     needs: [deploy, start-standard-change]
-    if: ${{ always() && needs.start-standard-change.result == 'success' }}
+    if: always() && needs.start-standard-change.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - run: echo Check env

--- a/.github/workflows/test-as-step.yml
+++ b/.github/workflows/test-as-step.yml
@@ -20,11 +20,11 @@ jobs:
       id: deploy
       run: exit 0
     - name: Test Outputs
-      if: ${{ always() }}
+      if: always() && steps.start-standard-change.outcome == 'success'
       run: echo Check env
       env:
         client-key: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_KEY }}
         client-secret: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_SECRET }}
         change-sys-id: ${{ steps.start-standard-change.outputs.change-sys-id }}
         work-start: ${{ steps.start-standard-change.outputs.work-start }}
-        success: ${{ steps.deploy.outcome == 'success' }}
+        success: ${{ job.status == 'success' }}

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ jobs:
         run: echo Deploy
       - name: End Standard Change
         uses: byu-oit/github-action-end-standard-change@v1
-        if: ${{ always() && steps.start-standard-change.outcome == 'success' }} # Run if RFC started, even if the deploy failed
+        if: always() && steps.start-standard-change.outcome == 'success' # Run if RFC started, even if the deploy failed
         with:
           client-key: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_KEY }}
           client-secret: ${{ secrets.STANDARD_CHANGE_SANDBOX_CLIENT_SECRET }}
           change-sys-id: ${{ steps.start-standard-change.outputs.change-sys-id }}
           work-start: ${{ steps.start-standard-change.outputs.work-start }}
-          success: ${{ steps.deploy.outcome == 'success' }}
+          success: ${{ job.status == 'success' }}
 ```
 
 </p>
@@ -63,6 +63,8 @@ jobs:
 <details>
 <summary>In a workflow where the deploy phase is a job, do this...</summary>
 <p>
+
+Have a job with an `id` of `deploy` (or change this example accordingly), then
 
 ```yaml
 on: push
@@ -98,7 +100,7 @@ jobs:
   end-standard-change:
     name: End Standard Change
     needs: [deploy, start-standard-change] # We need to wait on outcome of deploy, and we list start-standard-change so that we can grab its outputs
-    if: ${{ always() && needs.start-standard-change.result == 'success' }} # Run if RFC started, even if the deploy failed
+    if: always() && needs.start-standard-change.result == 'success' # Run if RFC started, even if the deploy failed
     runs-on: ubuntu-latest
     steps:
       - uses: byu-oit/github-action-end-standard-change@v1


### PR DESCRIPTION
We've now had two people get burned by the way `${{ steps.deploy.outcome == 'success' }}` silently evaluates to `false` when there's no step with an `id` of `deploy`.

The thinking is that 

- `success: ${{ success() }}` doesn't work as you might expect in the `continue-on-error` case, but otherwise works great
- `success: ${{ steps.deploy.outcome == 'success' }}` works great but silently fails if no step with an `id` of `deploy` exists (which apparently happens often when copying/pasting)
- `success: ${{ job.status == 'success' }}` probably works great when running `if: always() && steps.start-standard-change.outcome == 'success'`

Refs: https://github.com/byu-oit/github-action-end-standard-change/pull/10
Refs: https://byu-oit.slack.com/archives/CQ2BE663T/p1592410344429600
Refs: https://byu-oit.slack.com/archives/CQ2BE663T/p1595350304226300